### PR TITLE
Embed the license in the script header

### DIFF
--- a/report_print.rb
+++ b/report_print.rb
@@ -1,4 +1,18 @@
 #!/usr/bin/env ruby
+#
+# Copyright 2013-2016 R.I.Pienaar and contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 require 'puppet'
 require 'pp'


### PR DESCRIPTION
As this project is a standalone script, I think it would be useful to
embed the license in the header of the script.