### PR TITLE
BUGFIX: Remove trailing dash

### DIFF
--- a/report_print.rb
+++ b/report_print.rb
@@ -72,7 +72,7 @@ def color(code, msg, reset=false)
   colors.merge!(
     :changed   => colors[:yellow],
     :unchanged => colors[:green],
-    :failed    => colors[:red],
+    :failed    => colors[:red]
   )
 
   return "%s%s%s%s" % [colors.fetch(code, ""), msg, colors[:reset], reset ? colors.fetch(reset, "") : ""] if @options[:color]


### PR DESCRIPTION
Fixes issue on ruby-1.8.7.374-4.el6_6 witr trailing dash

https://github.com/ripienaar/puppet-reportprint/issues/9
